### PR TITLE
Fixed removeItemFromRoom() callback bug

### DIFF
--- a/src/rooms.js
+++ b/src/rooms.js
@@ -322,11 +322,16 @@ Room.prototype.addCorpse = function(s, monster, fn) {
 
 Room.prototype.removeItemFromRoom = function(roomQuery, fn) {
 	this.getRoomObject(roomQuery, function(roomObj) {
+		var removed=false;
 		roomObj.items = roomObj.items.filter(function(item, i) {
 			if (item.id !== roomQuery.item.id) {
-				return fn(true);
-			}			
-		});	
+				return true;
+			} else {
+				removed=true; // At least one item was successfully removed
+			}
+		});
+		if(removed)
+			fn();  // Invoke success callback
 	});
 }
 


### PR DESCRIPTION
Fixed removeItemFromRoom() - callback wasn't being fired correctly under some circumstances.  This caused the player to get no feedback after a 'get' command under some circumstances.
