### PR TITLE
Make item search more intuitive

### DIFF
--- a/src/character.js
+++ b/src/character.js
@@ -639,7 +639,7 @@ Character.prototype.checkInventory = function(r, s, fn) {
 		findItem = r.msg;
 	}
 
-	msgPatt = new RegExp('^' + findItem);
+	msgPatt = new RegExp(findItem);
 
 	items = s.player.items.filter(function(item, i) {
 		if (msgPatt.test(item.name.toLowerCase())) {

--- a/src/rooms.js
+++ b/src/rooms.js
@@ -311,7 +311,7 @@ Room.prototype.checkItem = function(r, s, fn) {
 		findItem = r.msg;
 	}
 
-	msgPatt = new RegExp('^' + findItem);
+	msgPatt = new RegExp(findItem);
 
 	this.getRoomObject({area: s.player.area, id: s.player.roomid}, function(roomObj) {
 		items = roomObj.items.filter(function (item, i) {


### PR DESCRIPTION
1. Removes '^' from Room.prototype.checkItem regex
2. Removes '^' from Character.prototype.checkInventory regex

For a Tattered Buckler you can now:
get buck
drop tatt
get Tattered Buckler
