### PR TITLE
advanced respawn logic

### DIFF
--- a/src/ticks.js
+++ b/src/ticks.js
@@ -80,19 +80,42 @@ World = require('./world').world;
 	// area.respawnOn (default is 3 -- 12 minutes). A respawnOn value of zero prevents respawn.
 	// areas do not update if someone is fighting
 	setInterval(function() {
-		var i = 0;
+		var i = 0,
+		j = 0,
+		k = 0,
+		canRefresh = true;
+		
 		if (World.areas.length) {
 			for (i; i < World.areas.length; i += 1) {
 				(function(area, index) {
-					World.reloadArea(area, function(area) {
-						World.areas[index] = area;
-					});
+					for (j; j < area.rooms.length; j += 1) {
+						(function(room, index, roomIndex) {
+							if (room.playersInRoom) {
+								if (area.respawnOn > 0) {
+									area.respawnTick += 1;
+								}
+
+//								if (area)
+
+								for (k; k < room.playersInRoom.length; k += 1) {
+									if (room.playersInRoom[k].position === 'fighting') {
+										canRefresh = false;
+									}
+								}
+							}
+
+							if (World.areas.length - 1 === index 
+								&& roomIndex === area.rooms.length - 1) {
+								World.reloadArea(area, function(area) {
+									World.areas[index] = area;
+								});
+							}
+						}(area.rooms[j], index, j));
+					}
 				}(World.areas[i], i))
 			}
 		}
-
-	//}, 240000); // 4 minutes
-	}, 5000);
+	}, 240000); // 4 minutes
 
 	// decay timer, anything at zero rots away
 	setInterval(function() {

--- a/src/ticks.js
+++ b/src/ticks.js
@@ -74,8 +74,7 @@ World = require('./world').world;
 		}
 	}, 1900);
 
-	// Areas refresh when they are devoid of players for at least four minutes
-	// if the area is not empty the respawnTick property on the area object increments by one
+	// If the area is not empty the respawnTick property on the area object increments by one
 	// areas with players 'in' them respawn every X ticks; where X is the value of
 	// area.respawnOn (default is 3 -- 12 minutes). A respawnOn value of zero prevents respawn.
 	// areas do not update if someone is fighting
@@ -83,32 +82,42 @@ World = require('./world').world;
 		var i = 0,
 		j = 0,
 		k = 0,
-		canRefresh = true;
+		refresh = true;
 		
 		if (World.areas.length) {
 			for (i; i < World.areas.length; i += 1) {
 				(function(area, index) {
+					if (area.respawnOn > 0) {
+						area.respawnTick += 1;
+					}
+
 					for (j; j < area.rooms.length; j += 1) {
 						(function(room, index, roomIndex) {
 							if (room.playersInRoom) {
-								if (area.respawnOn > 0) {
-									area.respawnTick += 1;
-								}
-
-//								if (area)
-
 								for (k; k < room.playersInRoom.length; k += 1) {
 									if (room.playersInRoom[k].position === 'fighting') {
-										canRefresh = false;
+										refresh = false;
+										area.respawnTick -= 1;
 									}
 								}
+
+								// if players were in the area roll a check to delay respawn
+								World.dice.roll(1, 20, function(roll) {
+									if (roll > 18) {
+										area.respawnTick -= 1;
+									}
+								});
 							}
 
 							if (World.areas.length - 1 === index 
 								&& roomIndex === area.rooms.length - 1) {
-								World.reloadArea(area, function(area) {
-									World.areas[index] = area;
-								});
+								if ((area.respawnTick === area.respawnOn && area.respawnOn > 0 && refresh)) {
+									World.reloadArea(area, function(area) {
+										area.respawnTick = 0;
+
+										World.areas[index] = area;
+									});
+								}
 							}
 						}(area.rooms[j], index, j));
 					}

--- a/src/world.js
+++ b/src/world.js
@@ -429,7 +429,7 @@ World.prototype.loadArea = function(areaName, fn) {
 		if (fnd) {
 			return fn(area, true);
 		} else {
-			area = require('../areas/' + areaName);
+			area = require('../areas/' + areaName.toLowerCase());
 
 			world.setupArea(area, function(area) {
 				world.areas.push(area);
@@ -466,9 +466,9 @@ World.prototype.reloadArea = function(area, fn) {
 	var world = this,
 	i = 0;
 
-	require.cache[require.resolve('../areas/' + area.name)] = null;
+	require.cache[require.resolve('../areas/' + area.name.toLowerCase())] = null;
 
-	area = require('../areas/' + area.name);
+	area = require('../areas/' + area.name.toLowerCase());
 
 	world.setupArea(area, function(area) {
 		if (typeof fn === 'function') {

--- a/src/world.js
+++ b/src/world.js
@@ -464,15 +464,24 @@ World.prototype.setupArea = function(area, fn) {
 
 World.prototype.reloadArea = function(area, fn) {
 	var world = this,
+	newArea,
 	i = 0;
 
-	require.cache[require.resolve('../areas/' + area.name.toLowerCase())] = null;
+	newArea = require('../areas/' + area.name.toLowerCase());
 
-	area = require('../areas/' + area.name.toLowerCase());
+	world.setupArea(newArea, function(newArea) {
+		var i = 0;
 
-	world.setupArea(area, function(area) {
+		for (i; i < area.rooms.length; i +=1) {
+			if (area.rooms[i].playersInRoom) {
+				newArea.rooms[i].playersInRoom = area.rooms[i].playersInRoom;
+			}
+		}
+		
+		require.cache[require.resolve('../areas/' + area.name.toLowerCase())] = null;
+
 		if (typeof fn === 'function') {
-			return fn(area);
+			return fn(newArea);
 		}
 	});
 };


### PR DESCRIPTION
 Areas refresh when they are devoid of players for at least four minutes if the area is not empty the respawnTick property on the area object increments by one. Areas with players respawn every X ticks; where X is the value of area.respawnOn (default is 3 -- 12 minutes). A respawnOn value of zero prevents respawn. Areas do not update if a player is fighting.